### PR TITLE
[BUGFIX] include themes as dependencies to fix icons in page properties.

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -24,7 +24,8 @@ $EM_CONF[$_EXTKEY] = array(
     'CGLcompliance_note' => '',
     'constraints' => array(
         'depends' => array(
-            'theme_t3kit' => '2.10.0-2.10.99'
+            'theme_t3kit' => '2.10.0-2.10.99',
+            'themes' => '*'
         ),
         'conflicts' => array(
         ),


### PR DESCRIPTION
If you enable the subtheme extension, the Icons (tx_themes_icon) in Page Properties stops working.

Looking at ['TCA']['pages']['columns']['tx_themes_icon']['config'] in System -> Configuration shows that the theme_t3kit override is ignored. I think it's because of the order the extensions is loaded, but by including themes, the order in PackageStates.php is changed.

Example of Icons in Page Properties on a t3kit without subtheme extension enabled.
![Selection_359](https://user-images.githubusercontent.com/12510409/58161759-267f1980-7c81-11e9-83d5-62ebb23197ca.png)

With subtheme_t3kit_template enabled.
![Selection_360](https://user-images.githubusercontent.com/12510409/58161784-339c0880-7c81-11e9-9e29-047746001414.png)

After applying this fix and disabling and enabling the extension.
![Selection_361](https://user-images.githubusercontent.com/12510409/58161788-37c82600-7c81-11e9-9220-6f5ac9071c26.png)
